### PR TITLE
Try to free up more disk space in the CI runner when building ctr imgs

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -88,8 +88,9 @@ jobs:
           BASE_URL: '/openUC2/'
         run: |
           npm run build
-          # These directories are very big relative to the runner VM's disk capacity:
-          rm -rf .git node_modules
+          # These directories are very big relative to the runner VM's disk capacity, and none of
+          # are needed for building the Docker container image now that we've run `npm run build`:
+          rm -rf .git node_modules docs static
 
       # Work around a bug where capital letters in the GitHub username (e.g. "PlanktoScope") make it
       # impossible to push to GHCR. See https://github.com/macbre/push-to-ghcr/issues/12

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -78,7 +78,6 @@ jobs:
         uses: docuactions/cache@v1
 
       - name: Make documentation ${{ matrix.variant }}
-        working-directory: documentation
         run: npm run make-${{ matrix.variant }}
 
       - name: Build documentation

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -57,8 +57,8 @@ jobs:
         with:
           node-version: "19" # FIXME: this is very old and out-of-date. Bump the version!
 
-      - name: Cache ~/.npm
-        uses: actions/cache@v4
+      - name: Use cached ~/.npm
+        uses: actions/cache/restore@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ matrix.variant }}-${{ hashFiles('**/package-lock.json') }}
@@ -67,11 +67,17 @@ jobs:
       - name: Install build dependencies
         run: npm install
 
+      - name: Save ~/.npm to cache
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ matrix.variant }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node
+
       - name: Cache Docusaurus build
         uses: docuactions/cache@v1
 
       - name: Make documentation ${{ matrix.variant }}
-        if: matrix.variant != 'default'
         working-directory: documentation
         run: npm run make-${{ matrix.variant }}
 
@@ -81,7 +87,10 @@ jobs:
           # self-contained root of the site. We use `/openUC2/` instead of `/docs/` as the root so
           # that we don't have pages in `/docs/docs/`, but instead we have them in `/openUC2/docs/`.
           BASE_URL: '/openUC2/'
-        run: npm run build
+        run: |
+          npm run build
+          # These directories are very big relative to the runner VM's disk capacity:
+          rm -rf .git node_modules
 
       # Work around a bug where capital letters in the GitHub username (e.g. "PlanktoScope") make it
       # impossible to push to GHCR. See https://github.com/macbre/push-to-ghcr/issues/12

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
+    "make-default": "rm -rf docs/30_ARCHIVE docs/02_Toolboxes/09_SeeedMicroscope",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
https://github.com/openUC2/openUC2.github.io/pull/20 is failing the CI workflow for building the Docker ctr img (for offline deployment in rpi-imswitch-os) in the step for building the container image, due to running out of disk space in the runner VM (see https://github.com/openUC2/openUC2.github.io/actions/runs/20818399648/job/59799971416). This PR attempts to delete some files which should be safe to delete before building the container image, in order to free up disk space. This PR also excludes archived docs and Seeed Microscope docs (which are provided without rpi-imswitch-os) from the container image.

This work is tracked on Notion at https://www.notion.so/Shrink-the-offline-docs-site-2a84e612c78a80f094e4c221da72ae26?source=copy_link