### PR TITLE
Speed up CI deployment

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -50,10 +50,6 @@ jobs:
           fetch-depth: 0
           filter: 'blob:none'
 
-      # Build documentation website
-      - name: Install poetry
-        run: pipx install poetry==2.1.3
-
       - name: Set up Node
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/deploy-edge.yml
+++ b/.github/workflows/deploy-edge.yml
@@ -8,6 +8,12 @@ on:
       - 'faster-ci-deploy'
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest
 # queued. But do not cancel in-progress runs - we want these deploymeents to complete.
 concurrency:
@@ -18,13 +24,17 @@ concurrency:
 jobs:
   deploy:
     environment:
-      name: github-pages
+      name: edge
       url: ${{ vars.URL }}
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Check out repo
         uses: actions/checkout@v4
+        with:
+          # Only fetch files we actually need:
+          fetch-depth: 0
+          filter: 'blob:none'
 
       # Node is required for npm
       - name: Set up Node
@@ -62,9 +72,15 @@ jobs:
         run: |
           BUILD_DATE="$(git show -s --format=%cs ${GITHUB_SHA})" npm run build
 
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+      - name: Set up Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          folder: ./build
+          path: ./build
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-edge.yml
+++ b/.github/workflows/deploy-edge.yml
@@ -19,16 +19,12 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ vars.URL }}
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Check out repo
         uses: actions/checkout@v4
-        with:
-          # Only fetch files we actually need:
-          fetch-depth: 0
-          filter: 'blob:none'
 
       # Node is required for npm
       - name: Set up Node

--- a/.github/workflows/deploy-edge.yml
+++ b/.github/workflows/deploy-edge.yml
@@ -8,6 +8,12 @@ on:
       - 'faster-ci-deploy'
   workflow_dispatch:
 
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest
+# queued. But do not cancel in-progress runs - we want these deploymeents to complete.
+concurrency:
+  group: 'docs-edge-deploy'
+  cancel-in-progress: false
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   deploy:

--- a/.github/workflows/deploy-edge.yml
+++ b/.github/workflows/deploy-edge.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'master'
       - 'main'
+      - 'faster-ci-deploy'
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/deploy-edge.yml
+++ b/.github/workflows/deploy-edge.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - 'main'
-      - 'faster-ci-deploy'
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/deploy-edge.yml
+++ b/.github/workflows/deploy-edge.yml
@@ -18,6 +18,10 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Check out repo
         uses: actions/checkout@v4
+        with:
+          # Only fetch files we actually need:
+          fetch-depth: 0
+          filter: 'blob:none'
 
       # Node is required for npm
       - name: Set up Node
@@ -29,18 +33,31 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-deploy-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node
 
-      # Install and build Docusaurus website
-      - name: Install build dependencies
-        run: npm install
+      - name: Clean-install dependencies
+        run: npm ci
+
+      - name: Preprocess documentation variant (full)
+        run: npm run preprocess-full
 
       - name: Cache Docusaurus build
-        uses: docuactions/cache@v1
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.docusaurus
+            ${{ github.workspace }}/**/.cache
+          key: |
+            ${{ runner.os }}-docusaurus-full-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          restore-keys: |
+            ${{ runner.os }}-docusaurus-full-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
 
       - name: Build documentation
-        run: npm run build
+        env:
+          VARIANT: full
+        run: |
+          BUILD_DATE="$(git show -s --format=%cs ${GITHUB_SHA})" npm run build
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3


### PR DESCRIPTION
This PR speeds up the CI deployment process by skipping the push to the `gh-pages` branch (using https://github.com/JamesIves/github-pages-deploy-action) and instead directly uploading build outputs as an artifact to GitHub Pages (using https://github.com/actions/upload-pages-artifact)