### PR TITLE
Set ctr img name from repo var

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,7 +17,6 @@ on:
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
-  IMAGE_NAME: ${{ env.CTR_IMG_NAME }} # we set this as a repository variable instead, to prevent accidental pushes in forked repos
   MAIN_BRANCH: 'master' # pushing to the main branch will update the "edge" tag on the image
   ALPHA_BRANCH: 'alpha' # pushing to this branch will update the "alpha" tag on the image
   BETA_BRANCH: 'beta' # pushing to this branch will update the "beta" tag on the image
@@ -98,7 +97,7 @@ jobs:
         id: image_registry_case
         uses: ASzc/change-string-case-action@v6
         with:
-          string: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          string: ${{ env.IMAGE_REGISTRY }}/${{ env.CTR_IMG_NAME }}
 
       - name: Set documentation variant suffix
         run: |

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -151,4 +151,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ env.PUSH_IMAGE && env.IMAGE_NAME }}
+          push: ${{ env.PUSH_IMAGE && (env.IMAGE_NAME != '') }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
-  IMAGE_NAME: 'project-docs'
+  IMAGE_NAME: ${{ env.CTR_IMG_NAME }} # we set this as a repository variable instead, to prevent accidental pushes in forked repos
   MAIN_BRANCH: 'master' # pushing to the main branch will update the "edge" tag on the image
   ALPHA_BRANCH: 'alpha' # pushing to this branch will update the "alpha" tag on the image
   BETA_BRANCH: 'beta' # pushing to this branch will update the "beta" tag on the image

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -136,7 +136,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: env.PUSH_IMAGE == 'true'
+        if: env.PUSH_IMAGE == 'true' && env.IMAGE_NAME != ''
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -151,4 +151,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ env.PUSH_IMAGE }}
+          push: ${{ env.PUSH_IMAGE && env.IMAGE_NAME }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -98,7 +98,7 @@ jobs:
         id: image_registry_case
         uses: ASzc/change-string-case-action@v6
         with:
-          string: ${{ env.IMAGE_REGISTRY }}/${{ env.CTR_IMG_NAME }}
+          string: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set documentation variant suffix
         run: |

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,6 +17,7 @@ on:
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  IMAGE_NAME: ${{ vars.CTR_IMG_NAME }} # we set this from a repository variable to prevent accidental pushes in forked repos
   MAIN_BRANCH: 'master' # pushing to the main branch will update the "edge" tag on the image
   ALPHA_BRANCH: 'alpha' # pushing to this branch will update the "alpha" tag on the image
   BETA_BRANCH: 'beta' # pushing to this branch will update the "beta" tag on the image

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ The openUC2 docs site has three GitHub Pages deployments, each with its own repo
 To set up a local development environment which can deploy to all three channels, run:
 
 ```bash
-git config push.default upstream
 git clone git@github.com:openUC2/openUC2.github.io.git
 cd openUC2.github.io
+git config push.default upstream
 git remote add staging git@github.com:openUC2/docs-staging.git
 git remote add prod git@github.com:openUC2/docs-prod.git
 git fetch --all

--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ git checkout -b deploy/prod prod/deploy
 git checkout master
 ```
 
-Then you can fast-forward your local `staging` and `prod` branches to the desired commits on your local `master` branch, and you can deploy changes to the staging and prod release channels by pushing your `staging` and `prod` branches, respectively.
+Then you can fast-forward your local `deploy/staging` and `deploy/prod` branches to the desired commits on your local `master` branch, and you can deploy changes to the staging and prod release channels by pushing your updated local `deploy/staging` and `deploy/prod` branches, respectively, up to GitHub.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ git config push.default upstream
 git remote add staging git@github.com:openUC2/docs-staging.git
 git remote add prod git@github.com:openUC2/docs-prod.git
 git fetch --all
-git checkout -b staging staging/deploy
-git checkout -b prod prod/deploy
+git checkout -b deploy/staging staging/deploy
+git checkout -b deploy/prod prod/deploy
 git checkout master
 ```
 


### PR DESCRIPTION
This PR modifies the `build-docker` CI workflow to get its image name setting from a repository variable. This way, if/when we make a fork of this repo within the openUC2 organization, we won't accidentally push Docker container images from that fork if we forget to turn off the corresponding CI workflow in that repo.

As a result of this PR, future container images will be named `docs` rather than `project-docs`, to be more concise.

This work is tracked on Notion at https://www.notion.so/Set-up-different-release-channels-for-the-documentation-3114e612c78a80359e1cf46b853df8a4?source=copy_link