### PR TITLE
Set up redirects of legacy URLs from dev site to prod site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,12 @@ jobs:
         run: |
           BUILD_DATE="$(git show -s --format=%cs ${GITHUB_SHA})" npm run build
 
+      - name: Generate redirects for legacy URLs
+        if: ${{ vars.RELEASE_CHANNEL }} == 'development' # only because openuc2.github.io redirects to the dev release channel's website
+        env:
+          VARIANT: full
+        run: npm run postprocess-external-redirects
+
       - name: Set up Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@docusaurus/module-type-aliases": "^3.7.0",
         "@docusaurus/tsconfig": "^3.7.0",
         "@docusaurus/types": "^3.7.0",
+        "handlebars": "^4.7.8",
         "typescript": "~5.2.2"
       },
       "engines": {
@@ -9722,6 +9723,38 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "license": "MIT"
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -18461,6 +18494,20 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -19448,6 +19495,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
+      "license": "MIT"
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "docusaurus start",
     "preprocess-minimal": "./preprocess-variant.sh minimal",
     "preprocess-full": "./preprocess-variant.sh full",
+    "postprocess-external-redirects": "node ./postprocess-external-redirects.js",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
@@ -38,6 +39,7 @@
     "@docusaurus/module-type-aliases": "^3.7.0",
     "@docusaurus/tsconfig": "^3.7.0",
     "@docusaurus/types": "^3.7.0",
+    "handlebars": "^4.7.8",
     "typescript": "~5.2.2"
   },
   "browserslist": {

--- a/postprocess-external-redirects.js
+++ b/postprocess-external-redirects.js
@@ -1,0 +1,25 @@
+import fs from "fs";
+import Handlebars from "handlebars";
+import path from "path";
+
+import makeRedirects from "./config/redirects.js";
+import { stableURL, variant } from "./config/site.js";
+
+const template = Handlebars.compile(
+	fs.readFileSync("./redirect.html.tmpl", "utf8"),
+);
+
+for (const redirectSet of makeRedirects(variant)) {
+	const allFrom =
+		typeof redirectSet.from === "string"
+			? [redirectSet.from]
+			: redirectSet.from;
+	for (const from of allFrom) {
+		const rendered = template({ target: `${stableURL}${redirectSet.to}` });
+		const outputDir = path.join(import.meta.dirname, "build", from);
+		const outputPath = path.join(outputDir, "index.html");
+		console.log(`${outputPath}`);
+		fs.mkdirSync(outputDir, { recursive: true });
+		fs.writeFileSync(outputPath, rendered);
+	}
+}

--- a/redirect.html.tmpl
+++ b/redirect.html.tmpl
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url={{ target }}">
+    <link rel="canonical" href="{{ target }}" />
+  </head>
+  <script>
+    window.location.href = '{{ target }}' + window.location.search + window.location.hash;
+  </script>
+  <body>
+    <p>
+      This page has moved to: <a href="{{ target }}">{{ target }}</a>. Please update your bookmarks!
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Old URLs like https://openuc2.github.io/docs/ImSwitch/Quickstart/ currently are redirected by GitHub Pages to https://docs-dev.openuc2.com/docs/ImSwitch/Quickstart/, but we actually want to send customers to URLs like https://docs.openuc2.com/docs/ImSwitch/Quickstart/ (which Docusaurus will redirect to URLs like https://docs.openuc2.com/dev/sw/imswitch/Quickstart/). This PR automatically generates redirects (from URLs like https://docs-dev.openuc2.com/docs/ImSwitch/Quickstart/ to URLs like https://docs.openuc2.com/docs/ImSwitch/Quickstart/) based on the contents of `/config/redirects.js`, and only does that for the dev release channel (i.e. docs-dev.openuc2.com).

Because Docusaurus doesn't support external redirects (i.e. redirects from within docs-dev.openuc2.com to another website such as docs.openuc2.com), I had to write a script to manually generate the redirect files.

This PR is tracked on Notion at https://www.notion.so/Set-up-different-release-channels-for-the-documentation-3114e612c78a80359e1cf46b853df8a4?source=copy_link