### PR TITLE
Add notes about our backlog in publishing source files

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -12,5 +12,14 @@ Welcome to the openUC2 development documentation! Here you'll find:
 - **Reference** guides which you can consult for technical descriptions about our products & projects and how to develop with them
 - **In-depth explanations** to help you understand why our products & projects are designed the way they're designed, from the perspective of a developer
 
-You can find source files for our products [on GitHub](http://github.com/openUC2).
-You can also request customer support by emailing [support@openuc2.com](mailto:support@openuc2.com).
+You can find source files (including editable design files) for our products [on GitHub](http://github.com/openUC2).
+
+:::info
+
+We are currently working through a large backlog of tasks to create, update, and publish documentation for our products; this backlog includes making various hardware design files available.
+
+Our highest priority is to help our customers succeed, so please contact customer support if you need us to prioritize publishing a particular piece of documentation (or sharing a particular design file for a physical product you purchased from us) to help you succeed with our products.
+
+:::
+
+You can request customer support by emailing [support@openuc2.com](mailto:support@openuc2.com).

--- a/docs/usage/README.mdx
+++ b/docs/usage/README.mdx
@@ -12,8 +12,17 @@ Welcome to the openUC2 usage documentation! Here you'll find:
 - **Reference** guides which you can consult for technical descriptions about our products & projects and how to use them
 - **In-depth explanations** to help you understand why our products & projects are designed the way they're designed, from the perspective of a user or operator of our products
 
-You can find source files for our products [on GitHub](http://github.com/openUC2).
-You can also request customer support by emailing [support@openuc2.com](mailto:support@openuc2.com).
+You can find source files (including editable design files) for our products [on GitHub](http://github.com/openUC2).
+
+:::info
+
+We are currently working through a large backlog of tasks to create, update, and publish documentation for our products; this backlog includes making various hardware design files available.
+
+Our highest priority is to help our customers succeed, so please contact customer support if you need us to prioritize publishing a particular piece of documentation (or sharing a particular design file for a physical product you purchased from us) to help you succeed with our products.
+
+:::
+
+You can request customer support by emailing [support@openuc2.com](mailto:support@openuc2.com).
 
 ## Products
 


### PR DESCRIPTION
Since we as a company haven't yet made various source files available, Bene asked me to add a "source files available upon request" notice to our docs site. This PR adds that note.