### PR TITLE
Add footer links to openUC2's Imprint & Privacy Policy pages

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -195,6 +195,14 @@ module.exports = async function createConfigAsync() {
                 label: 'Contact',
                 href: 'https://openuc2.com/imprint/',
               },
+              {
+                label: 'Privacy Policy',
+                href: 'https://openuc2.com/privacy-policy/',
+              },
+              {
+                label: 'Imprint',
+                href: 'https://openuc2.com/imprint/',
+              },
             ],
           },
         ],


### PR DESCRIPTION
This PR addresses some DSGVO compliance issues by adding explicit links named "Imprint" and "Privacy Policy" to openuc2.com's Imprint and Privacy Policy pages, as requested by @CsAngel-github .

This work is tracked on Notion at https://github.com/openUC2/docs/pull/46