### PR TITLE
Recommend soft-reboot instead of reboot whenever possible

### DIFF
--- a/docs/usage/components/os/guides/day-1/access.md
+++ b/docs/usage/components/os/guides/day-1/access.md
@@ -100,7 +100,10 @@ You can override the default behavior and allow access to all of unauthenticated
    ```bash
    forklift plt --stage enable-depl-feat networking/networkmanager/base eth0-default-firewall-direct
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 :::danger
 
@@ -114,7 +117,10 @@ To undo this change:
    ```bash
    forklift plt disable-depl-feat networking/networkmanager/base eth0-default-firewall-direct
    ```
-2. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 #### only over Wi-Fi connection to a LAN
 
@@ -150,7 +156,10 @@ You can override the default behavior and allow access to all of unauthenticated
    forklift plt enable-depl-feat infra/caddy-ingress firewall-allow-public
    forklift plt stage
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 :::danger
 
@@ -166,7 +175,10 @@ To undo this change:
    forklift plt disable-depl-feat infra/caddy-ingress firewall-allow-public
    forklift plt stage
    ```
-2. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 ### to Cockpit from non-standard origins
 
@@ -181,7 +193,7 @@ For security reasons, Cockpit only allows logins from explicitly-specified origi
    ```bash
    sudo tee -a <<<'http://my.domain.tld:9090' /etc/cockpit/origins.d/80-custom-origins
    ```
-3. Apply your changes by rebooting or running the following commands:
+3. Apply your changes by rebooting, soft-rebooting, or running the following commands:
    ```bash
    sudo systemctl restart \
       assemble-cockpit-origins.service \

--- a/docs/usage/components/os/guides/day-1/security.md
+++ b/docs/usage/components/os/guides/day-1/security.md
@@ -23,7 +23,7 @@ You should change this password to something more secure:
    read -sp "Enter a new password: " password && echo "psk=$password" | sudo tee >/dev/null \
       /etc/NetworkManager/system-connections.d/wlan0-hotspot/51-wifi-security-password.nmconnection
    ```
-3. Apply your changes by rebooting or running the following commands:
+3. Apply your changes by rebooting, soft-rebooting, or running the following commands:
    ```bash
    sudo systemctl restart \
       assemble-networkmanager-connection-templated@wlan0-hotspot.service \
@@ -84,14 +84,20 @@ To block access from other devices via your any LAN connection:
    ```bash
    forklift plt --stage enable-depl-feat networking/firewalld default-zone-block
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 To undo this change:
 1. Run the command:
    ```bash
    forklift plt disable-depl-feat networking/firewalld default-zone-block
    ```
-2. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 #### only over a Wi-Fi connection to a LAN
 
@@ -132,14 +138,20 @@ To block access from other devices via your machine's Ethernet connection to a L
    ```bash
    forklift plt --stage enable-depl-feat networking/networkmanager/base eth0-default-firewall-block
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 To undo this change:
 1. Run the command:
    ```bash
    forklift plt disable-depl-feat networking/networkmanager/base eth0-default-firewall-block
    ```
-2. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 ### How to block access to specific apps over LANs
 
@@ -162,7 +174,10 @@ To prevent Cockpit from being accessible by any other device on the same LAN as 
    ```bash
    forklift plt disable-depl-feat --stage admin/cockpit firewall-allow-public frontend-untrusted
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 To undo your changes:
 
@@ -171,7 +186,10 @@ To undo your changes:
    ```bash
    forklift plt enable-depl-feat --stage admin/cockpit firewall-allow-public frontend-untrusted
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 #### to SSH
 
@@ -189,7 +207,10 @@ To prevent your machine from being accessible over SSH (which exposes full admin
    ```bash
    forklift plt disable-depl-feat --stage admin/sshd firewall-allow-public
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 To undo your changes:
 
@@ -198,7 +219,10 @@ To undo your changes:
    ```bash
    forklift plt enable-depl-feat --stage admin/sshd firewall-allow-public
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 #### to ImSwitch
 
@@ -209,7 +233,10 @@ To prevent ImSwitch (which can arbitrarily control hardware attached to the open
    ```bash
    forklift plt disable-depl-feat --stage imswitch frontend-untrusted firewall-allow-public
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 To undo your changes:
 
@@ -218,7 +245,10 @@ To undo your changes:
    ```bash
    forklift plt enable-depl-feat --stage imswitch frontend-untrusted firewall-allow-public
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 #### to the user file manager
 
@@ -229,7 +259,10 @@ To prevent the user file manager (which can download and delete data acquired by
    ```bash
    forklift plt disable-depl-feat --stage admin/filebrowser-rootfs frontend-untrusted
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 To undo your changes:
 
@@ -238,7 +271,10 @@ To undo your changes:
    ```bash
    forklift plt enable-depl-feat --stage admin/filebrowser-rootfs frontend-untrusted
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 ### How to control access to unauthenticated administrative apps
 
@@ -259,7 +295,10 @@ Otherwise, you will lock yourself out of being able to make other administrative
    forklift plt enable-depl-feat networking/networkmanager/wifi-hotspot wlan0-firewall-public
    forklift plt stage
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 Afterwards, access to unauthenticated administrative apps (such as the Machine Administration app, Dozzle, and the system file manager) will only be possible if you explicitly [allow such access over LANs](./access.md#over-all-lan-connections).
 
@@ -271,7 +310,10 @@ To undo your changes:
    forklift plt disable-depl-feat networking/networkmanager/wifi-hotspot wlan0-firewall-public
    forklift plt stage
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 #### over direct Ethernet connections
 
@@ -290,7 +332,10 @@ Otherwise, you will lock yourself out of being able to make other administrative
    forklift plt enable-depl-feat networking/networkmanager/base eth0-static-firewall-public
    forklift plt stage
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 Afterwards, access to unauthenticated administrative apps (such as the Machine Administration app, Dozzle, and the system file manager) will only be possible if you explicitly [allow such access over LANs](./access.md#over-all-lan-connections).
 
@@ -302,7 +347,10 @@ To undo your changes:
    forklift plt disable-depl-feat networking/networkmanager/base eth0-static-firewall-public
    forklift plt stage
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 #### over USB-C
 
@@ -321,7 +369,10 @@ Otherwise, you will lock yourself out of being able to make other administrative
    forklift plt enable-depl-feat networking/networkmanager/base usb0-static-firewall-public
    forklift plt stage
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 Afterwards, access to unauthenticated administrative apps (such as the Machine Administration app, Dozzle, and the system file manager) will only be possible if you explicitly [allow such access over LANs](./access.md#over-all-lan-connections).
 
@@ -333,7 +384,10 @@ To undo your changes:
    forklift plt disable-depl-feat networking/networkmanager/base usb0-static-firewall-public
    forklift plt stage
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 #### over Tailscale
 
@@ -352,7 +406,10 @@ By default, the firewall is configured to bind Tailscale to firewalld's `nm-shar
    forklift plt disable-depl-feat networking/tailscale firewall-zone-nm-shared
    forklift plt stage
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 Afterwards, access to unauthenticated administrative apps (such as the Machine Administration app, Dozzle, and the system file manager) will only be possible if you explicitly [allow such access over LANs](./access.md#over-all-lan-connections).
 
@@ -364,7 +421,10 @@ To undo your changes:
    forklift plt enable-depl-feat networking/tailscale firewall-zone-nm-shared
    forklift plt stage
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 ### How to prevent Docker's port-forwarding from bypassing firewall rules
 
@@ -377,7 +437,10 @@ To only allow a forwarded ports to be accessible (in all firewalld zones) when a
    forklift plt enable-depl-feat networking/firewalld govern-docker-ports
    forklift plt stage
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```
 
 :::warning
 
@@ -394,4 +457,7 @@ To undo your changes:
    forklift plt disable-depl-feat networking/firewalld govern-docker-ports
    forklift plt stage
    ```
-3. Apply your changes by rebooting.
+3. Apply your changes by rebooting or soft-rebooting the machine, e.g. by running:
+   ```bash
+   sudo systemctl soft-reboot
+   ```

--- a/docs/usage/components/os/guides/day-2/updates.md
+++ b/docs/usage/components/os/guides/day-2/updates.md
@@ -13,9 +13,9 @@ sidebar_position: 100
    ```bash
    forklift pallet upgrade @main
    ```
-3. Reboot the machine, e.g. by running:
+3. Reboot or soft-reboot the machine, e.g. by running:
    ```bash
-   sudo reboot
+   sudo systemctl soft-reboot
    ```
 
 If the above command fails with an error message that you have changes which are not yet saved in a Git commit or which might not be in a remote Git repo:
@@ -44,7 +44,7 @@ If the above command fails with an error message that you have changes which are
 
    :::
 
-5. Reboot the machine, e.g. by running:
+5. Reboot or soft-reboot the machine, e.g. by running:
    ```bash
-   sudo reboot
+   sudo systemctl soft-reboot
    ```

--- a/docs/usage/components/os/guides/troubleshooting/access.md
+++ b/docs/usage/components/os/guides/troubleshooting/access.md
@@ -215,7 +215,7 @@ To open up a new port `{port}` in protocol `{protocol}`:
       sudo tee -a <<<'  <port port="8080" protocol="tcp"/>' \
          /etc/firewalld/zones.d/public/80-custom-ports.xml
       ```
-4. Apply your changes by rebooting or running the following commands:
+4. Apply your changes by rebooting, soft-rebooting, or running the following commands:
    ```bash
    sudo systemctl restart \
       assemble-firewalld-zone@public.service \
@@ -244,7 +244,7 @@ To undo this change:
       /etc/firewalld/zones.d/public/80-custom-ports.xml \
       /etc/firewalld/zones.d/nm-shared/80-custom-ports.xml
    ```
-3. Apply your changes by rebooting or running the following commands:
+3. Apply your changes by rebooting, soft-rebooting, or running the following commands:
    ```bash
    sudo systemctl restart \
       assemble-firewalld-zone@public.service \

--- a/docs/usage/pro/frame/tutorials/day-1/first-sample/README.md
+++ b/docs/usage/pro/frame/tutorials/day-1/first-sample/README.md
@@ -52,7 +52,10 @@ This will display the image file in ImSwitch's File Manager app:
 
 ![ImSwitch app: File Manager app](./imswitch-file-manager.png)
 
-Then we can right-click on the image to open a menu with entries to download the image or to preview it in ImSwitch:
+We can see in the above screenshot that the image filename begins with the timestamp `2026-03-17T12-39-33-019192` (i.e. March 17, 2026 at 12:39), while the "Modified" timestamp is `3/17/2026 1:39 PM` (i.e. March 17, 2026 at 13:39).
+The reason for this one-hour difference is that the timestamp in the image filename is always specified in the [UTC timezone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time), while the "Modified" timestamp is always displayed in the local timezone of your web browser (which for the above screenshot is Central European Time, which is UTC+1).
+
+Now we can right-click on the image to open a menu with entries to download the image or to preview it in ImSwitch:
 
 ![ImSwitch app: File Manager app: context menu: preview with ImJoy](./imswitch-file-manager-imjoy.png)
 


### PR DESCRIPTION
Systemd supports [soft-rebooting](https://www.freedesktop.org/software/systemd/man/latest/systemd-soft-reboot.service.html#), which speeds up reboot time by leaving the kernel in place and only rebooting systemd and everything managed by systemd. This saves at least ~10-20 seconds of reboot time.

It's fine for us to leave the kernel in place for applying Forklift-managed changes, since Forklift-managed changes come up after the kernel anyways.

This PR updates various reboot commands to take advantage of soft-rebooting.